### PR TITLE
Fix MeshCentral redir and undefined exception

### DIFF
--- a/amt-redir-node-0.1.0.js
+++ b/amt-redir-node-0.1.0.js
@@ -97,6 +97,7 @@ var CreateAmtRedirect = function (module) {
     obj.xxOnSocketData = function (data) {
         if (!data || obj.connectstate == -1) return;
 
+        if (typeof(data)=='string') {data = new Buffer(data,'binary')}
         // Redirection tracing
         if (urlvars && urlvars['redirtrace']) {
             var datastr = arrToStr(new Uint8Array(data));

--- a/index.html
+++ b/index.html
@@ -5461,7 +5461,7 @@
             // ###END###{Desktop}
 
             // Intel AMT user Consent
-            if ((amtversion > 5) && (amtsysstate['IPS_OptInService'] != null) && (amtsysstate['IPS_OptInService'].response != undefined)) {
+            if ((amtversion > 5) && (amtsysstate != null && amtsysstate['IPS_OptInService'] != null) && (amtsysstate['IPS_OptInService'].response != undefined)) {
                 features = "Unknown state";
                 var optinrequired = amtsysstate['IPS_OptInService'].response['OptInRequired'];
                 if (optinrequired == 0) { features = "Not Required"; }
@@ -8202,7 +8202,7 @@
             connectDesktopConsent = false; // TODO, this is not a good idea when calls are pending.
             if (desktop.State == 0) {
                 // Check if user consent is needed
-                if ((skipConsent !== true) && (amtversion > 5) && (amtsysstate['IPS_OptInService'] != null) && (amtsysstate['IPS_OptInService'].response != undefined) && (amtsysstate['IPS_OptInService'].response['OptInRequired'] == 0xFFFFFFFF)) {
+                if ((skipConsent !== true) && (amtversion > 5) && (amtsysstate != null) && (amtsysstate['IPS_OptInService'] != null) && (amtsysstate['IPS_OptInService'].response != undefined) && (amtsysstate['IPS_OptInService'].response['OptInRequired'] == 0xFFFFFFFF)) {
                     connectDesktopConsent = true; amtstack.Get('IPS_OptInService', powerActionResponse0, 0, 1); return; // User consent always required, ask for it before KVM.
                 }
                 // Encoding Flags: 1 = RLE, 2 = 16bit, 4 = Gray, 8 = ZLib


### PR DESCRIPTION
When redirection traffic is relayed over MeshCentral, the stream is binary string. The required format for processing is Buffer. In order to solve this issue, the data need to be converted to Buffer if the incoming type is detected as binary string.

Also fixed an issue where MeshCommander checks amtsysstate for opt-in whereas initial WSMAN pull has not been done. This caused exception. So, extra check is added on amtsysstate before accessing amtsysstate['xxxx'].